### PR TITLE
Changes base URL + fixes missing header image on sub pages

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-baseURL: https://maxkratz.github.io/emoflon-website-deploy
+baseURL: https://emoflon.org
 languageCode: en-us
 defaultContentLanguage: en
 title: eMoflon Project Site
@@ -16,7 +16,7 @@ permalinks:
 
 params:
   # Header text, can be markdown
-  project_name: "![](img/emoflon_logo_with_tex_semitransparent_300px.png)"
+  project_name: "![](/img/emoflon_logo_with_tex_semitransparent_300px.png)"
   project_tagline: "**eMoflon** is a tool suite for Model-Driven Engineering (MDE) that provides a range of visual and formal languages for (meta)modelling and model management."
 
   # Theme customizations by us


### PR DESCRIPTION
Closes #17. Closes #8.

This should be merged right before changing the deployment to the actual emoflon.org repository.