### PR TITLE
Fixes two deprecated config names used in our theme (hugo build error) + updates hugo version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Hugo version to use
-  VERSION: "0.101.0"
+  VERSION: "0.134.2"
   # Hugo release source
   HUGO_RELEASE_SRC: "https://github.com/gohugoio/hugo/releases"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Install Hugo
         run: |
-          export HUGO_DEB_FILE=hugo_extended_${VERSION}_Linux-64bit.deb
+          export HUGO_DEB_FILE=hugo_extended_${VERSION}_linux-amd64.deb
           echo "Using URL: $HUGO_RELEASE_SRC/download/v$VERSION/$HUGO_DEB_FILE"
           wget -q $HUGO_RELEASE_SRC/download/v$VERSION/$HUGO_DEB_FILE
           sudo dpkg -i $HUGO_DEB_FILE

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ For contributing, you need the following things:
 
 Please follow this (official) [installation guide of Hugo](https://gohugo.io/getting-started/installing/).
 
-This project uses Hugo version `0.101.0` **extended** or newer.
+This project uses Hugo version `0.134.2` **extended** or newer.
 Please notice that some standard packet sources like Debian/Ubuntu **do not provide the minimum required version**.
 
-The easiest way to get the required version up and running is to download it from [Github](https://github.com/gohugoio/hugo/releases/tag/v0.101.0) and install it by hand.
+The easiest way to get the required version up and running is to download it from [Github](https://github.com/gohugoio/hugo/releases/tag/v0.134.2) and install it by hand.
 Detailed steps for an installation from Github [are described on this page](https://gohugo.io/getting-started/installing/#install-hugo-from-tarball).
 
 It is important that you can start Hugo from your terminal and that it states the correct version number.
@@ -55,7 +55,7 @@ You may check it using this command:
 
 ```bash
 $ hugo version
-hugo v0.101.0-466fa43c16709b4483689930a4f9ac8add5c9f66+extended linux/amd64 BuildDate=2022-06-16T07:09:16Z VendorInfo=gohugoio
+hugo v0.134.2+extended darwin/arm64 BuildDate=2024-09-10T10:46:33Z VendorInfo=brew
 ```
 
 **Tip**: Use the exact version stated above to prevent version incompatibilities.

--- a/layouts/partials/disqus.html
+++ b/layouts/partials/disqus.html
@@ -1,0 +1,6 @@
+{{ $ctx := . }}
+{{ with $.Site.Config.Services.Disqus.Shortname }}
+  {{ if ne . "yourdiscussshortname" }}
+    {{ template "_internal/disqus.html" $ctx }}
+  {{ end }}
+{{ end }}

--- a/layouts/partials/google-analytics-async.html
+++ b/layouts/partials/google-analytics-async.html
@@ -1,0 +1,10 @@
+{{ if not hugo.IsServer }}
+  {{ with $.Site.GoogleAnalytics }}
+  <script>
+  window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+  ga('create', '{{ . }}', 'auto');
+  ga('send', 'pageview');
+  </script>
+  <script async src='https://www.google-analytics.com/analytics.js'></script>
+  {{ end }}
+{{ end }}

--- a/layouts/partials/google-analytics-async.html
+++ b/layouts/partials/google-analytics-async.html
@@ -1,5 +1,5 @@
 {{ if not hugo.IsServer }}
-  {{ with $.Site.GoogleAnalytics }}
+  {{ with $.Site.Config.Services.GoogleAnalytics.ID }}
   <script>
   window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
   ga('create', '{{ . }}', 'auto');


### PR DESCRIPTION
Newer versions of hugo fail to build the page with the old config options used in our theme.